### PR TITLE
Inline fancybox-initalized images disappear when clicked

### DIFF
--- a/public/lib/main.js
+++ b/public/lib/main.js
@@ -3,7 +3,7 @@
 
 	jQuery('document').ready(function() {
 		$(window).on('action:ajaxify.end', function() {
-			$('[component="post/content"] .img-markdown').attr('rel', 'gallery').fancybox();
+			$('[component="post/content"] .img-markdown').attr('rel', 'gallery').parent().addClass("fancybox").fancybox();
 		});
 	});
 }());


### PR DESCRIPTION
Issue #10, add class "fancybox" to link containing the image and init fancybox on a tag, no img one, see https://github.com/fancyapps/fancyBox/issues/169 for details.